### PR TITLE
Don't require waiting for release to merge branch

### DIFF
--- a/general/development-process.md
+++ b/general/development-process.md
@@ -117,7 +117,7 @@ For example:
 
 ### Merge Feature Branch into Develop Branch
 
-Once the pull request is approved, merge the feature branch into the `develop` branch when the feature is about to be released.
+Once the pull request is approved, the finished feature branch may be merged into the `develop` branch to definitely add it to the upcoming release.
 
 If the `develop` branch has changed since you last merged then follow Merge Latest Develop Branch into Feature Branch, Push Feature Branch, and Peer Review Feature Branch instructions again. (The reviewer does not need to complete a full review, but does need to review and approve the final merged code for any issues with possible merge conflicts. This is enforced by the required GitHub branch protection settings.)
 


### PR DESCRIPTION
The current wording for merging a feature branch is too prescriptive. If all PRs have to wait until you're ready to create a release branch, it could hold things up even further. For example, if a branch has not been updated for a while, the yarn lockfile may need to be changed, which will trigger yet another code review. I prefer to merge PRs into develop as soon as the PRs are approved. I like the wording Gitflow uses:

> Finished features may be merged into the develop branch to definitely add them to the upcoming release.

I'm suggesting we use similar wording for our own documentation.